### PR TITLE
Fix syntax highlighting in the installation code

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Well-documented vignette and tutorial is available from the following URL:
 ## Installation
 One can install ASURAT by the following code:
 
-```{r}
+```r
 if (!require("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 


### PR DESCRIPTION
This fixes syntax highlighting in the installation code in `README.md`.

Before:

```{r}
if (!require("BiocManager", quietly = TRUE))
    install.packages("BiocManager")

# The following initializes usage of Bioc devel
BiocManager::install(version='devel')

BiocManager::install("ASURAT")
```

After:

```r
if (!require("BiocManager", quietly = TRUE))
    install.packages("BiocManager")

# The following initializes usage of Bioc devel
BiocManager::install(version='devel')

BiocManager::install("ASURAT")
```